### PR TITLE
Feature - Sketchy

### DIFF
--- a/keyboards/pikatea/sketchy/mcuconf.h
+++ b/keyboards/pikatea/sketchy/mcuconf.h
@@ -3,7 +3,7 @@
 #include_next <mcuconf.h>
 
 #undef RP_I2C_USE_I2C0
-#define RP_I2C_USE_I2C0 TRUE
+#define RP_I2C_USE_I2C0 FALSE
 
 #undef RP_I2C_USE_I2C1
-#define RP_I2C_USE_I2C1 FALSE
+#define RP_I2C_USE_I2C1 TRUE


### PR DESCRIPTION
Per this [i2c-driver](https://github.com/PikateaCompany/vial-qmk/blob/vial/docs/platformdev_rp2040.md#i2c-driver) we need to set the correct `mcuconf.h` value
